### PR TITLE
Restore example code with modular interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 确保已安装 `RPi.GPIO`，然后执行:
 
 ```bash
-python3 read_photoresistor.py
+python3 main.py
 ```
 
 脚本每秒打印一次测定的光照值。

--- a/main.py
+++ b/main.py
@@ -1,0 +1,29 @@
+import argparse
+import time
+import RPi.GPIO as GPIO  # type: ignore
+
+from photoresistor import rc_time
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Read photoresistor value")
+    parser.add_argument(
+        "--pin",
+        type=int,
+        default=17,
+        help="GPIO pin connected to the photoresistor",
+    )
+    args = parser.parse_args()
+
+    GPIO.setmode(GPIO.BCM)
+    try:
+        while True:
+            value = rc_time(args.pin)
+            print(f"\u5149\u7167\u503C: {value}")
+            time.sleep(1)
+    finally:
+        GPIO.cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/photoresistor.py
+++ b/photoresistor.py
@@ -1,0 +1,17 @@
+import time
+import RPi.GPIO as GPIO  # type: ignore
+
+
+__all__ = ["rc_time"]
+
+
+def rc_time(pin: int) -> int:
+    """Return the charge time for the given GPIO pin."""
+    count = 0
+    GPIO.setup(pin, GPIO.OUT)
+    GPIO.output(pin, GPIO.LOW)
+    time.sleep(0.1)
+    GPIO.setup(pin, GPIO.IN)
+    while GPIO.input(pin) == GPIO.LOW:
+        count += 1
+    return count


### PR DESCRIPTION
## Summary
- bring back a usable photoresistor example
- split functionality into `photoresistor.py` module and `main.py`
- update README instructions

## Testing
- `python3 -m py_compile photoresistor.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6877366246fc8331bd5895418db4bbba