### PR TITLE
Switch to lgpio

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 3. **DATA** → 默认连接至 GPIO17（可使用 `--pin` 参数修改）
 ## 运行示例
 
-确保已安装 `RPi.GPIO`，然后执行:
+确保已安装 `lgpio`，然后执行:
 
 ```bash
 python3 main.py

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import argparse
 import time
-import RPi.GPIO as GPIO  # type: ignore
+import lgpio
 
 from photoresistor import rc_time
 
@@ -15,14 +15,14 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    GPIO.setmode(GPIO.BCM)
+    handle = lgpio.gpiochip_open(0)
     try:
         while True:
-            value = rc_time(args.pin)
+            value = rc_time(handle, args.pin)
             print(f"\u5149\u7167\u503C: {value}")
             time.sleep(1)
     finally:
-        GPIO.cleanup()
+        lgpio.gpiochip_close(handle)
 
 
 if __name__ == "__main__":

--- a/photoresistor.py
+++ b/photoresistor.py
@@ -1,17 +1,17 @@
 import time
-import RPi.GPIO as GPIO  # type: ignore
+import lgpio
 
 
 __all__ = ["rc_time"]
 
 
-def rc_time(pin: int) -> int:
+def rc_time(handle: int, pin: int) -> int:
     """Return the charge time for the given GPIO pin."""
     count = 0
-    GPIO.setup(pin, GPIO.OUT)
-    GPIO.output(pin, GPIO.LOW)
+    lgpio.gpio_claim_output(handle, pin, lgpio.LOW)
     time.sleep(0.1)
-    GPIO.setup(pin, GPIO.IN)
-    while GPIO.input(pin) == GPIO.LOW:
+    lgpio.gpio_claim_input(handle, pin)
+    while lgpio.gpio_read(handle, pin) == lgpio.LOW:
         count += 1
+    lgpio.gpio_free(handle, pin)
     return count


### PR DESCRIPTION
## Summary
- replace `RPi.GPIO` usage with `lgpio`
- update photoresistor helper to claim pins via `lgpio`
- document dependency change in README

## Testing
- `python3 -m py_compile main.py photoresistor.py`
- `python3 main.py --pin 17` *(fails: ModuleNotFoundError: No module named 'lgpio')*

------
https://chatgpt.com/codex/tasks/task_e_68775a3474488331aab97a5ca19002e2